### PR TITLE
Add cached search page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@
 import React from "react";
 import { gql, useSubscription } from "@apollo/client";
 import SiteList from "./SiteList";
+import SearchPage from "./SearchPage";
+import { Routes, Route, useNavigate } from "react-router-dom";
 
 const TIME_SUBSCRIPTION = gql`
   subscription {
@@ -19,6 +21,7 @@ function randomMorse(len: number) {
 export default function App() {
   const { data, loading, error } = useSubscription(TIME_SUBSCRIPTION);
   const display = data?.time ? randomMorse(data.time.length) : "…";
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-black flex flex-col items-center p-6 space-y-12">
@@ -44,8 +47,11 @@ export default function App() {
         )}
       </div>
 
-      {/* New supported‐sites list */}
-      <SiteList />
+      <Routes>
+        <Route path="/" element={<SiteList onSelect={(s) => navigate(`/${s}`)} />} />
+        <Route path="/:site" element={<SearchPage />} />
+      </Routes>
     </div>
   );
 }
+

--- a/frontend/src/SearchPage.tsx
+++ b/frontend/src/SearchPage.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { gql, useLazyQuery } from "@apollo/client";
+import { useParams } from "react-router-dom";
+
+const SEARCH = gql`
+  query Search($site: String!, $query: String!, $limit: Int) {
+    search(site: $site, query: $query, limit: $limit) {
+      id
+      title
+      url
+      thumbnail
+    }
+  }
+`;
+
+export default function SearchPage() {
+  const { site = "" } = useParams();
+  const [term, setTerm] = React.useState("");
+  const [runSearch, { data, loading, error }] = useLazyQuery(SEARCH);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!term) return;
+    runSearch({ variables: { site, query: term, limit: 5 } });
+  };
+
+  return (
+    <div className="w-full max-w-3xl space-y-6">
+      <h2 className="text-yellow-400 text-center text-2xl font-semibold capitalize">
+        {site}
+      </h2>
+      <form onSubmit={handleSubmit} className="flex">
+        <input
+          type="text"
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+          placeholder="Search"
+          className="flex-grow bg-black border-2 border-yellow-400 rounded-l px-4 py-2 text-yellow-400 focus:outline-none"
+        />
+        <button
+          type="submit"
+          className="bg-black border-2 border-yellow-400 rounded-r px-4 py-2 text-yellow-400 hover:bg-yellow-400 hover:text-black focus:bg-yellow-400 focus:text-black"
+        >
+          Go
+        </button>
+      </form>
+      {loading && <p className="text-yellow-400">Loading…</p>}
+      {error && <p className="text-yellow-400">Error: {error.message}</p>}
+      {data && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {data.search.map((item: any) => (
+            <a
+              key={item.id}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-black border-2 border-yellow-400 rounded-lg p-4 flex flex-col transition duration-200 hover:bg-yellow-400 hover:text-black focus:bg-yellow-400 focus:text-black"
+            >
+              {item.thumbnail && (
+                <img
+                  src={item.thumbnail}
+                  alt="thumbnail"
+                  className="w-full h-40 object-cover mb-2 rounded"
+                />
+              )}
+              <span className="text-yellow-400 font-medium">{item.title}</span>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/SiteList.tsx
+++ b/frontend/src/SiteList.tsx
@@ -1,5 +1,9 @@
 // src/SiteList.tsx
 import React from "react";
+
+interface Props {
+  onSelect?: (site: string) => void;
+}
 import { gql, useQuery } from "@apollo/client";
 
 const SUPPORTED_SITES = gql`
@@ -8,7 +12,7 @@ const SUPPORTED_SITES = gql`
   }
 `;
 
-export default function SiteList() {
+export default function SiteList({ onSelect }: Props) {
   const { data, loading, error } = useQuery(SUPPORTED_SITES);
 
   if (loading) return <p className="text-yellow-400">Loading…</p>;
@@ -29,9 +33,10 @@ export default function SiteList() {
         {data.supportedSites.map((site: string) => (
           <button
             key={site}
+            onClick={() => onSelect && onSelect(site)}
             className="
-              bg-black 
-              border-2 border-yellow-400 
+              bg-black
+              border-2 border-yellow-400
               rounded-lg 
               h-24 
               flex items-center justify-center 
@@ -55,3 +60,4 @@ export default function SiteList() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- cache `search` results on the backend
- expose a dedicated search page on the frontend
- navigate to search when clicking a site card

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing React and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_684d518594bc83268405b6368a0d92c0