### PR TITLE
Improve loading UX and yt-dlp resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ venv/
 # Media & static
 media/
 staticfiles/
+node_modules/

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -71,14 +71,21 @@ async def resolve_search(obj, info, site, query, limit):
 
     # Offload subprocess.run to a thread pool
     def run_yt_dlp():
-        return subprocess.run(
-            ["yt-dlp", "--dump-json", prefix],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout
+        try:
+            result = subprocess.run(
+                ["yt-dlp", "--dump-json", prefix],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            print(f"yt-dlp failed: {e.stderr}")
+            return ""
 
     stdout = await asyncio.get_event_loop().run_in_executor(None, run_yt_dlp)
+    if not stdout:
+        return []
 
     # Parse lines into a Python list
     items = []

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { gql, useSubscription } from "@apollo/client";
 import SiteList from "./SiteList";
 import SearchPage from "./SearchPage";
+import LoadingBar from "./LoadingBar";
 import { Routes, Route, useNavigate } from "react-router-dom";
 
 const TIME_SUBSCRIPTION = gql`
@@ -40,7 +41,7 @@ export default function App() {
 
       {/* Optional Morse “clock” */}
       <div className="bg-black border-2 border-yellow-400 p-8 rounded-lg text-center">
-        {loading && <p className="text-yellow-400">Connecting…</p>}
+        {loading && <LoadingBar />}
         {error && <p className="text-yellow-400">Error: {error.message}</p>}
         {!loading && !error && (
           <pre className="text-yellow-400 text-4xl font-mono leading-snug">{display}</pre>

--- a/frontend/src/LoadingBar.tsx
+++ b/frontend/src/LoadingBar.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function LoadingBar() {
+  return (
+    <div className="w-full bg-yellow-400 h-1 animate-pulse" />
+  );
+}

--- a/frontend/src/SearchPage.tsx
+++ b/frontend/src/SearchPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { gql, useLazyQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
+import LoadingBar from "./LoadingBar";
 
 const SEARCH = gql`
   query Search($site: String!, $query: String!, $limit: Int) {
@@ -41,14 +42,14 @@ export default function SearchPage() {
           type="submit"
           className="bg-black border-2 border-yellow-400 rounded-r px-4 py-2 text-yellow-400 hover:bg-yellow-400 hover:text-black focus:bg-yellow-400 focus:text-black"
         >
-          Go
+          &rarr;
         </button>
       </form>
-      {loading && <p className="text-yellow-400">Loading…</p>}
+      {loading && <LoadingBar />}
       {error && <p className="text-yellow-400">Error: {error.message}</p>}
       {data && (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {data.search.map((item: any) => (
+          {data.search.map((item: {id: string; title: string; url: string; thumbnail?: string | null}) => (
             <a
               key={item.id}
               href={item.url}

--- a/frontend/src/SiteList.tsx
+++ b/frontend/src/SiteList.tsx
@@ -5,6 +5,7 @@ interface Props {
   onSelect?: (site: string) => void;
 }
 import { gql, useQuery } from "@apollo/client";
+import LoadingBar from "./LoadingBar";
 
 const SUPPORTED_SITES = gql`
   query SupportedSites {
@@ -15,7 +16,7 @@ const SUPPORTED_SITES = gql`
 export default function SiteList({ onSelect }: Props) {
   const { data, loading, error } = useQuery(SUPPORTED_SITES);
 
-  if (loading) return <p className="text-yellow-400">Loading…</p>;
+  if (loading) return <LoadingBar />;
   if (error)   return <p className="text-yellow-400">Error: {error.message}</p>;
 
   return (


### PR DESCRIPTION
## Summary
- handle `yt-dlp` errors in the backend and return empty results instead of crashing
- add a reusable yellow LoadingBar component
- use LoadingBar during app, site list and search page loads
- replace "Go" text with an arrow icon
- ignore `node_modules`

## Testing
- `npm run lint`
- `python -m py_compile backend/schema.py`


------
https://chatgpt.com/codex/tasks/task_e_684d52b6f8488326bafa45350861a202