### PR TITLE
Deduplicate supported sites

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -16,7 +16,9 @@ try:
         text=True,
         check=True,
     ).stdout
-    CACHED_EXTRACTORS = [line.strip() for line in _raw.splitlines() if line.strip()]
+    _extractors = [line.strip() for line in _raw.splitlines() if line.strip()]
+    # Ensure no duplicates while preserving order
+    CACHED_EXTRACTORS = list(dict.fromkeys(_extractors))
 except Exception:
     CACHED_EXTRACTORS = []
 

--- a/frontend/src/SiteList.tsx
+++ b/frontend/src/SiteList.tsx
@@ -18,6 +18,9 @@ export default function SiteList({ onSelect }: Props) {
   if (loading) return <p className="text-yellow-400">Loading…</p>;
   if (error)   return <p className="text-yellow-400">Error: {error.message}</p>;
 
+  // Remove any duplicate entries that might come from the API
+  const sites = Array.from(new Set(data.supportedSites));
+
   return (
     <div className="w-full max-w-6xl">
       <div
@@ -30,7 +33,7 @@ export default function SiteList({ onSelect }: Props) {
           gap-4
         "
       >
-        {data.supportedSites.map((site: string) => (
+        {sites.map((site: string) => (
           <button
             key={site}
             onClick={() => onSelect && onSelect(site)}


### PR DESCRIPTION
## Summary
- ensure the list of extractors returned by the backend contains no duplicates
- deduplicate the site list in the frontend before rendering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d52db4fa48326bca25fdfb7faa858