### PR TITLE
Fix Windows async subprocess support

### DIFF
--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -17,7 +17,7 @@ from .schema import schema
 
 # On Windows, ensure subprocess support for asyncio
 if sys.platform.startswith("win"):
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
 # Tell Django where to find settings and bootstrap
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,7 @@ import asyncio
 def main():
     """Run administrative tasks."""
     if sys.platform.startswith("win"):
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
     try:
         from django.core.management import execute_from_command_line


### PR DESCRIPTION
## Summary
- use `WindowsProactorEventLoopPolicy` in `asgi.py` and `manage.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d5e5e444c832697f1ec7cbf065099