### PR TITLE
Fix Proactor loop initialization timing

### DIFF
--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -3,6 +3,10 @@
 import os
 import sys
 import asyncio
+
+if sys.platform.startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
 import django
 
 from django.core.asgi import get_asgi_application


### PR DESCRIPTION
## Summary
- move Windows Proactor loop setup to happen before importing Django

## Testing
- `python -m py_compile backend/asgi.py`


------
https://chatgpt.com/codex/tasks/task_e_684d708b7dd883269c91ae4ed2edaf72