### PR TITLE
Fix demucs invocation

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -2,6 +2,7 @@ import subprocess
 import json
 import urllib.parse
 from pathlib import Path
+import sys
 
 from ariadne import make_executable_schema, QueryType, MutationType, gql
 import torch
@@ -188,7 +189,7 @@ def resolve_separate_stems(_, __, filename: str, model: str):
 
     gpu_flag = "--gpu" if torch.cuda.is_available() else "--cpu"
     proc = subprocess.run(
-        ["demucs", model, "--out", str(out_dir), gpu_flag, str(src_path)],
+        [sys.executable, "-m", "demucs.separate", model, "--out", str(out_dir), gpu_flag, str(src_path)],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary
- use `sys.executable -m demucs.separate` so the demucs CLI works even if the binary isn't on PATH

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684db75889c4832685c297662a5a4541