### PR TITLE
Fix path join in startup script

### DIFF
--- a/start-copyright.ps1
+++ b/start-copyright.ps1
@@ -8,7 +8,7 @@ if (!(Test-Path $venvPath)) {
 }
 
 # Activate the environment
-$activate = Join-Path $venvPath 'Scripts' 'Activate.ps1'
+$activate = Join-Path (Join-Path $venvPath 'Scripts') 'Activate.ps1'
 & $activate
 
 # Upgrade pip and install common requirements


### PR DESCRIPTION
## Summary
- fix incorrect `Join-Path` usage for virtualenv activation

## Testing
- `python -m py_compile backend/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dbb60b42c8326b7cd1363dcfe7bf1