### PR TITLE
Fix Join-Path usage for node_modules check

### DIFF
--- a/start-copyright.ps1
+++ b/start-copyright.ps1
@@ -33,7 +33,7 @@ if ($gpu) {
 }
 
 # Ensure frontend deps
-if (!(Test-Path (Join-Path $PSScriptRoot 'frontend' 'node_modules'))) {
+if (!(Test-Path (Join-Path (Join-Path $PSScriptRoot 'frontend') 'node_modules'))) {
     Push-Location frontend
     npm install
     Pop-Location


### PR DESCRIPTION
## Summary
- fix Join-Path usage when checking `node_modules`

## Testing
- `pwsh -Command "Get-Command Join-Path"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbbfdb2208326857a5f240257a7f2