### PR TITLE
Fix separation command and style checkboxes

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -189,7 +189,17 @@ def resolve_separate_stems(_, __, filename: str, model: str):
 
     gpu_flag = "--gpu" if torch.cuda.is_available() else "--cpu"
     proc = subprocess.run(
-        [sys.executable, "-m", "demucs.separate", model, "--out", str(out_dir), gpu_flag, str(src_path)],
+        [
+            sys.executable,
+            "-m",
+            "demucs.separate",
+            "-n",
+            model,
+            "--out",
+            str(out_dir),
+            gpu_flag,
+            str(src_path),
+        ],
         capture_output=True,
         text=True,
     )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -316,7 +316,7 @@ export default function App() {
                             type="checkbox"
                             checked={!!desiredSel[name]}
                             onChange={() => toggleDesired(name)}
-                            className="accent-yellow-400"
+                            className="bg-yellow-400 border-yellow-400 rounded accent-black"
                           />
                           <span className="text-yellow-400 text-sm">{name}</span>
                         </label>
@@ -338,7 +338,7 @@ export default function App() {
                             type="checkbox"
                             checked={!!sel[s.name]}
                             onChange={() => toggle(s.name)}
-                            className="accent-yellow-400"
+                            className="bg-yellow-400 border-yellow-400 rounded accent-black"
                           />
                           <span className="text-yellow-400 text-sm">
                             {`${f.title}_${s.name}`}


### PR DESCRIPTION
## Summary
- update demucs CLI invocation to specify model name
- style checkboxes so boxes are yellow with black check marks

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `pip install -r requirements.txt`
- `python manage.py check`
- `npm --prefix frontend run build` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_684dd2acd62c8326bad464d03fd4c1cc