### PR TITLE
Improve separation menu UX

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -298,9 +298,20 @@ export default function App() {
                             }))
                           }
                           disabled={inQueue}
-                          className="bg-yellow-400 text-black text-sm font-bold px-2 py-1 rounded hover:bg-yellow-300 disabled:opacity-50"
+                          className="flex items-center bg-yellow-400 text-black text-sm font-bold px-2 py-1 rounded hover:bg-yellow-300 disabled:opacity-50"
                         >
-                          {inQueue ? "Separating..." : "Separate"}
+                          {inQueue ? (
+                            "Separating..."
+                          ) : (
+                            <>
+                              <span>Separate</span>
+                              <FaChevronDown
+                                className={
+                                  isChoosing ? "ml-1 transform rotate-180" : "ml-1"
+                                }
+                              />
+                            </>
+                          )}
                         </button>
                       </div>
                       {inQueue && (
@@ -316,7 +327,7 @@ export default function App() {
                             type="checkbox"
                             checked={!!desiredSel[name]}
                             onChange={() => toggleDesired(name)}
-                            className="bg-yellow-400 border-yellow-400 rounded accent-black"
+                            className="yellow-checkbox"
                           />
                           <span className="text-yellow-400 text-sm">{name}</span>
                         </label>
@@ -338,7 +349,7 @@ export default function App() {
                             type="checkbox"
                             checked={!!sel[s.name]}
                             onChange={() => toggle(s.name)}
-                            className="bg-yellow-400 border-yellow-400 rounded accent-black"
+                            className="yellow-checkbox"
                           />
                           <span className="text-yellow-400 text-sm">
                             {`${f.title}_${s.name}`}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,3 +2,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Custom checkbox style: yellow box with black check mark */
+.yellow-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 1rem; /* 16px */
+  height: 1rem;
+  border-radius: 0.25rem; /* rounded */
+  border: 1px solid #facc15; /* yellow-400 */
+  background-color: #facc15; /* yellow box */
+  position: relative;
+  cursor: pointer;
+}
+.yellow-checkbox:checked::after {
+  content: "";
+  position: absolute;
+  top: 0.1rem;
+  left: 0.29rem;
+  width: 0.25rem;
+  height: 0.55rem;
+  border: solid #000;
+  border-width: 0 0.125rem 0.125rem 0;
+  transform: rotate(45deg);
+}


### PR DESCRIPTION
## Summary
- style checkboxes with new yellow-black theme
- show a dropdown arrow on the Separate button to indicate expanded state

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684dd5aa544c832698bac480442ddc8e