### PR TITLE
Hide arrow when no stems

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -268,19 +268,21 @@ export default function App() {
                         <span className="text-yellow-400 font-semibold">
                           {f.title} (Audio)
                         </span>
-                        <button
-                          onClick={() =>
-                            setExpanded((p) => ({
-                              ...p,
-                              [f.filename]: !isExpanded,
-                            }))
-                          }
-                          className="text-yellow-400"
-                        >
-                          <FaChevronDown
-                            className={isExpanded ? "transform rotate-180" : ""}
-                          />
-                        </button>
+                        {stems.length > 0 && (
+                          <button
+                            onClick={() =>
+                              setExpanded((p) => ({
+                                ...p,
+                                [f.filename]: !isExpanded,
+                              }))
+                            }
+                            className="text-yellow-400"
+                          >
+                            <FaChevronDown
+                              className={isExpanded ? "transform rotate-180" : ""}
+                            />
+                          </button>
+                        )}
                       </div>
                       <div className="flex mt-2 space-x-2 self-end">
                         <a


### PR DESCRIPTION
## Summary
- hide the dropdown arrow on audio cards when there are no stems available

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dd7834b5083269f208c7006e08e6a