### PR TITLE
Fix stem separation output path and add mp3 support

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -106,7 +106,7 @@ def resolve_downloads(_, __):
         if typ == "audio":
             stems_dir = MEDIA_DIR / vid / "stems"
             if stems_dir.exists():
-                for stem_file in sorted(stems_dir.glob("*.wav")):
+                for stem_file in sorted(stems_dir.glob("*.mp3")):
                     stems_list.append({
                         "name": stem_file.stem,
                         "url": build_media_url(f"{vid}/stems/{stem_file.name}"),
@@ -197,6 +197,9 @@ def resolve_separate_stems(_, __, filename: str, model: str):
             model,
             "--out",
             str(out_dir),
+            "--filename",
+            "{stem}.{ext}",
+            "--mp3",
             gpu_flag,
             str(src_path),
         ],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -213,7 +213,7 @@ export default function App() {
                     if (stem) {
                       const a = document.createElement("a");
                       a.href = stem.url;
-                      a.download = `${f.title} (${name}).wav`;
+                      a.download = `${f.title} (${name}).mp3`;
                       a.click();
                     }
                   }


### PR DESCRIPTION
## Summary
- store separated stems as mp3 instead of wav
- ensure demucs writes files directly into the `stems` folder
- let frontend download mp3 stem files

## Testing
- `python manage.py check`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd5cd831c8326af51d02ecf347e6f