### PR TITLE
Handle demucs output folders

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -106,10 +106,10 @@ def resolve_downloads(_, __):
         if typ == "audio":
             stems_dir = MEDIA_DIR / vid / "stems"
             if stems_dir.exists():
-                for stem_file in sorted(stems_dir.glob("*.mp3")):
+                for stem_file in sorted(stems_dir.rglob("*.mp3")):
                     stems_list.append({
                         "name": stem_file.stem,
-                        "url": build_media_url(f"{vid}/stems/{stem_file.name}"),
+                        "url": build_media_url(f"{vid}/stems/{stem_file.relative_to(stems_dir)}"),
                     })
 
         items.append({
@@ -187,7 +187,8 @@ def resolve_separate_stems(_, __, filename: str, model: str):
     out_dir = MEDIA_DIR / vid / "stems"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    device_flag = f"--device={'cuda' if torch.cuda.is_available() else 'cpu'}"
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device_flag = f"--device={device}"
     proc = subprocess.run(
         [
             sys.executable,
@@ -206,7 +207,7 @@ def resolve_separate_stems(_, __, filename: str, model: str):
         capture_output=True,
         text=True,
     )
-    logs = proc.stdout + proc.stderr
+    logs = f"Using device: {device}\n" + proc.stdout + proc.stderr
     success = proc.returncode == 0
     return {"success": success, "logs": logs}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -246,6 +246,7 @@ export default function App() {
                   .then(({ data }) => {
                     const text = data?.separateStems?.logs || "";
                     setLogs((p) => ({ ...p, [f.filename]: text }));
+                    setExpanded((p) => ({ ...p, [f.filename]: true }));
                   })
                   .finally(() =>
                     setQueue((p) => ({ ...p, [f.filename]: false }))


### PR DESCRIPTION
## Summary
- capture GPU device in separation log output
- search subdirectories for separated stems
- auto-expand audio card once stems finish generating

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684de1bfd1088326928dbdf92fb856a4