### PR TITLE
Fix torch install command and adjust loading UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ On Windows, use `start-copyright.ps1` to create a virtual environment and instal
 If you set up the environment manually, be sure to install the appropriate PyTorch build. For GPU acceleration, run:
 
 ```powershell
-python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+python -m pip install --force-reinstall --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 ```
 
 Then start Django:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -148,21 +148,23 @@ export default function App() {
 
       {/* Download Buttons */}
       {videoId && (
-        <div className="w-full max-w-md flex flex-col sm:flex-row gap-4">
-          <button
-            onClick={() => downloadAudio({ variables: { url } })}
-            disabled={anyLoading}
-            className="flex-1 bg-yellow-400 text-black font-bold py-2 rounded hover:bg-yellow-300 disabled:opacity-50"
-          >
-            Download Audio
-          </button>
-          <button
-            onClick={() => downloadVideo({ variables: { url } })}
-            disabled={anyLoading}
-            className="flex-1 bg-yellow-400 text-black font-bold py-2 rounded hover:bg-yellow-300 disabled:opacity-50"
-          >
-            Download Video
-          </button>
+        <div className="w-full max-w-md">
+          <div className="flex flex-col sm:flex-row gap-4">
+            <button
+              onClick={() => downloadAudio({ variables: { url } })}
+              disabled={anyLoading}
+              className="flex-1 bg-yellow-400 text-black font-bold py-2 rounded hover:bg-yellow-300 disabled:opacity-50"
+            >
+              Download Audio
+            </button>
+            <button
+              onClick={() => downloadVideo({ variables: { url } })}
+              disabled={anyLoading}
+              className="flex-1 bg-yellow-400 text-black font-bold py-2 rounded hover:bg-yellow-300 disabled:opacity-50"
+            >
+              Download Video
+            </button>
+          </div>
           {anyLoading && (
             <div className="w-full h-2 bg-yellow-400 animate-pulse mt-2" />
           )}

--- a/start-copyright.ps1
+++ b/start-copyright.ps1
@@ -33,7 +33,7 @@ if ($forceCuda) {
 if ($gpu) {
     Write-Host "GPU detected - installing CUDA build of torch"
     # Force reinstall to ensure the CUDA-enabled build replaces any CPU-only version
-    python -m pip install --force-reinstall --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+    python -m pip install --force-reinstall --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 } else {
     Write-Host "No GPU detected - installing CPU build of torch"
     python -m pip install --force-reinstall --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary
- update README to use CUDA 11.8 wheels
- install CUDA 11.8 torch build in the Windows helper script
- place loading bar below download buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e01c77e60832681f93d0db2867138