### PR TITLE
Fix async subprocess and show logs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -164,9 +164,6 @@ export default function App() {
               Download Video
             </button>
           </div>
-          {anyLoading && (
-            <div className="w-full h-2 bg-yellow-400 animate-pulse mt-2" />
-          )}
           {globalLogs && (
             <div className="mt-2 p-2 bg-black border border-yellow-400 rounded overflow-auto max-h-40">
               <pre className="text-yellow-400 text-xs whitespace-pre-wrap">
@@ -330,9 +327,6 @@ export default function App() {
                           )}
                         </button>
                       </div>
-                      {inQueue && (
-                        <div className="h-2 bg-yellow-400 animate-pulse mt-1" />
-                      )}
                     </div>
                   </div>
                   {isChoosing && (


### PR DESCRIPTION
## Summary
- handle Windows asyncio subprocess limitations by falling back to `subprocess.Popen`
- remove pulsing progress bars in the React UI so logs are shown during operations
- run `black` on backend

## Testing
- `pytest -q`
- `npm run lint`
- `black backend/schema.py --check`


------
https://chatgpt.com/codex/tasks/task_e_684e7a31456c83269a26c084f3744834