### PR TITLE
Fix demucs model and keep progress logs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,7 +86,7 @@ export default function App() {
   const startDownloadAudio = () => {
     if (!videoId) return;
     setDownloading(true);
-    setGlobalLogs("");
+    setGlobalLogs("Starting download...\n");
     client
       .subscribe({ query: DOWNLOAD_AUDIO_PROGRESS, variables: { url } })
       .subscribe({
@@ -95,7 +95,8 @@ export default function App() {
         },
         complete() {
           setDownloading(false);
-          setGlobalLogs("");
+          setGlobalLogs((p) => p + "\nDownload complete\n");
+          setTimeout(() => setGlobalLogs(""), 5000);
           refetch();
         },
       });
@@ -104,7 +105,7 @@ export default function App() {
   const startDownloadVideo = () => {
     if (!videoId) return;
     setDownloading(true);
-    setGlobalLogs("");
+    setGlobalLogs("Starting download...\n");
     client
       .subscribe({ query: DOWNLOAD_VIDEO_PROGRESS, variables: { url } })
       .subscribe({
@@ -113,7 +114,8 @@ export default function App() {
         },
         complete() {
           setDownloading(false);
-          setGlobalLogs("");
+          setGlobalLogs((p) => p + "\nDownload complete\n");
+          setTimeout(() => setGlobalLogs(""), 5000);
           refetch();
         },
       });
@@ -251,7 +253,7 @@ export default function App() {
                 client
                   .subscribe({
                     query: SEPARATE_STEMS_PROGRESS,
-                    variables: { filename: f.filename, model: "htdemucs" },
+                    variables: { filename: f.filename, model: "htdemucs_6s" },
                   })
                   .subscribe({
                     next({ data }) {


### PR DESCRIPTION
## Summary
- keep download progress logs visible for a few seconds instead of clearing immediately
- use the 6‑stem `htdemucs_6s` model for separation so guitar and piano are available

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e7dde735483269821f87461f418bb