### PR TITLE
Enable selecting stems for separation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,8 +34,12 @@ const DOWNLOAD_VIDEO_PROGRESS = gql`
 `;
 
 const SEPARATE_STEMS_PROGRESS = gql`
-  subscription SeparateStemsProgress($filename: String!, $model: String!) {
-    separateStemsProgress(filename: $filename, model: $model)
+  subscription SeparateStemsProgress(
+    $filename: String!
+    $model: String!
+    $stems: [String!]!
+  ) {
+    separateStemsProgress(filename: $filename, model: $model, stems: $stems)
   }
 `;
 
@@ -241,6 +245,9 @@ export default function App() {
                 }));
               };
               const startSeparation = () => {
+                const selectedStems = Object.entries(desiredSel)
+                  .filter(([, v]) => v)
+                  .map(([n]) => n);
                 setQueue((p) => ({ ...p, [f.filename]: true }));
                 setChoosing((p) => ({ ...p, [f.filename]: false }));
                 setDesired((p) => ({
@@ -253,7 +260,11 @@ export default function App() {
                 client
                   .subscribe({
                     query: SEPARATE_STEMS_PROGRESS,
-                    variables: { filename: f.filename, model: "htdemucs_6s" },
+                    variables: {
+                      filename: f.filename,
+                      model: "htdemucs_6s",
+                      stems: selectedStems,
+                    },
                   })
                   .subscribe({
                     next({ data }) {


### PR DESCRIPTION
## Summary
- support requesting only certain stems in the GraphQL API
- pass selected stems from frontend when starting a separation job
- build demucs command with `--subset` or `--two-stems` flags accordingly

## Testing
- `python -m py_compile backend/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e87a31c6083268d3e7e4a39745305