### PR TITLE
Fix Windows async subprocess

### DIFF
--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -1,7 +1,13 @@
 # backend/asgi.py
 
+import sys
+import asyncio
 import os
 import django
+
+# Ensure Windows uses the Proactor event loop so that asyncio subprocesses work
+if sys.platform.startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
 from django.core.asgi import get_asgi_application
 from channels.routing import ProtocolTypeRouter, URLRouter


### PR DESCRIPTION
## Summary
- set WindowsProactorEventLoopPolicy before importing Django in `backend/asgi.py`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e9086d69883268c4cfd1b44be81e5