### PR TITLE
Fix event loop policy order

### DIFF
--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -3,11 +3,12 @@
 import sys
 import asyncio
 import os
-import django
 
 # Ensure Windows uses the Proactor event loop so that asyncio subprocesses work
 if sys.platform.startswith("win"):
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+import django
 
 from django.core.asgi import get_asgi_application
 from channels.routing import ProtocolTypeRouter, URLRouter


### PR DESCRIPTION
## Summary
- on Windows, set event loop policy before importing Django

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python -m flake8` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_684e92968f808326989f59a4c6a576d1