### PR TITLE
Fix closing brace in React map

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -373,7 +373,7 @@ export default function App() {
                   </div>
                 </div>
               );
-              });
+              })}
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- fix closing brace when rendering video download option

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684e96e375f8832687bfc1ce5a94de1c