### PR TITLE
Fix closing braces in App component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -373,7 +373,8 @@ export default function App() {
                   </div>
                 </div>
               );
-              })}
+            }
+          })}
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- fix closing braces for React map function in App.tsx

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_684e9a65c2588326873dbec32cb800d6