### PR TITLE
Fix missing icon import

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import {
   FaMicrophone,
   FaQuestionCircle,
 } from "react-icons/fa";
-import { GiDrumKit, GiGuitarBass, GiPianoKeys } from "react-icons/gi";
+import { GiDrumKit, GiGuitarBassHead, GiPianoKeys } from "react-icons/gi";
 import type { IconType } from "react-icons";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -53,7 +53,7 @@ const SEPARATE_STEMS_PROGRESS = gql`
 const AVAILABLE_STEMS = ["bass", "drums", "guitar", "other", "piano", "vocals"];
 
 const STEM_DETAILS: Record<string, { label: string; Icon: IconType }> = {
-  bass: { label: "Bass", Icon: GiGuitarBass },
+  bass: { label: "Bass", Icon: GiGuitarBassHead },
   drums: { label: "Drums", Icon: GiDrumKit },
   guitar: { label: "Guitar", Icon: FaGuitar },
   other: { label: "Other", Icon: FaQuestionCircle },


### PR DESCRIPTION
## Summary
- fix incorrect bass icon import

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e9ee84a048326880ccee3ea4226a8