### PR TITLE
Add stem preloading with loading bar

### DIFF
--- a/frontend/src/CustomPlayer.tsx
+++ b/frontend/src/CustomPlayer.tsx
@@ -8,9 +8,11 @@ export interface Stem {
 export function CustomPlayer({
   stems,
   selected,
+  preloaded = {},
 }: {
   stems: Stem[];
   selected: string[];
+  preloaded?: Record<string, AudioBuffer>;
 }) {
   const audioCtxRef = useRef<AudioContext>();
   const buffersRef = useRef<Record<string, AudioBuffer>>({});
@@ -29,6 +31,20 @@ export function CustomPlayer({
       audioCtxRef.current?.close();
     };
   }, []);
+
+  // Merge preloaded buffers on mount
+  useEffect(() => {
+    if (Object.keys(preloaded).length) {
+      buffersRef.current = { ...buffersRef.current, ...preloaded };
+      const maxDur = Math.max(
+        0,
+        ...Object.values(preloaded).map((b) => b.duration)
+      );
+      if (maxDur > 0) {
+        setDuration((d) => Math.max(d, maxDur));
+      }
+    }
+  }, [preloaded]);
 
   // Load buffers when a stem is first selected
   useEffect(() => {
@@ -115,6 +131,7 @@ export function CustomPlayer({
         max={duration}
         value={played}
         onChange={(e) => seekTo(+e.target.value)}
+        style={{ accentColor: "black" }}
         className="w-full"
       />
 


### PR DESCRIPTION
## Summary
- preload stems on expansion and store decoded buffers
- show pulsing bar while stems are loading
- pass preloaded buffers to `CustomPlayer`
- make slider accent black

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `python manage.py check` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ea571ef4c83268db9a34e965f92bb