### PR TITLE
Improve logo layout and audio player UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,18 +151,16 @@ export default function App() {
 
   return (
     <>
-      <header className="w-full bg-black flex items-center justify-center p-4">
-        <div className="inline-flex items-center">
-          <div
-            className="bg-yellow-400 flex items-center justify-center"
-            style={{ width: 64, height: 64 }}
-          >
-            <img src="/favicon.svg" alt="Logo" className="w-12 h-12" />
-          </div>
-          <h1 className="ml-4 text-3xl sm:text-4xl text-yellow-400 font-extrabold">
-            Copyright <span className="text-black bg-yellow-400 px-2">Violation</span>
-          </h1>
+      <header className="w-full bg-black flex flex-col items-center p-4 space-y-2">
+        <div
+          className="bg-yellow-400 flex items-center justify-center"
+          style={{ width: 64, height: 64 }}
+        >
+          <img src="/favicon.svg" alt="Logo" className="w-16 h-16" />
         </div>
+        <h1 className="text-3xl sm:text-4xl text-yellow-400 font-extrabold text-center">
+          Copyright <span className="text-black bg-yellow-400 px-2">Violation</span>
+        </h1>
       </header>
 
       <main className="min-h-screen bg-black flex flex-col items-center p-4 sm:p-6 space-y-8 sm:space-y-12">

--- a/frontend/src/CustomPlayer.tsx
+++ b/frontend/src/CustomPlayer.tsx
@@ -124,46 +124,25 @@ export function CustomPlayer({
   }, [isPlaying]);
 
   return (
-    <div className="w-full max-w-lg bg-yellow-400 text-black p-4 rounded-lg space-y-4">
+    <div className="w-full max-w-lg bg-black text-yellow-400 border border-yellow-400 p-4 rounded-lg space-y-4">
       <button
         onClick={togglePlay}
-        className="px-4 py-2 bg-black text-yellow-400 rounded font-bold"
+        className="w-full px-4 py-2 bg-yellow-400 text-black rounded font-bold"
       >
         {isPlaying ? "❚❚ Pause" : "▶ Play"}
       </button>
 
-      <div className="relative w-full">
-        {/* Invisible native range for interaction */}
-        <input
-          type="range"
-          min={0}
-          max={duration}
-          value={played}
-          onChange={(e) => seekTo(+e.target.value)}
-          className="absolute inset-0 w-full h-3 opacity-0 cursor-pointer"
-        />
+      <input
+        type="range"
+        min={0}
+        max={duration}
+        value={played}
+        onChange={(e) => seekTo(+e.target.value)}
+        className="w-full h-2 rounded bg-black"
+        style={{ accentColor: "#facc15" }}
+      />
 
-        {/* Track + Fill */}
-        <div className="h-3 bg-black rounded-full overflow-hidden">
-          <div
-            className="h-full bg-yellow-400 transition-all duration-150"
-            style={{ width: `${(duration ? (played / duration) * 100 : 0)}%` }}
-          />
-        </div>
-
-        {/* Modern circular thumb */}
-        <div
-          className="absolute w-6 h-6 rounded-full bg-black border-2 border-white shadow-lg"
-          style={{
-            left: `${(duration ? (played / duration) * 100 : 0)}%`,
-            top: "50%",
-            transform: "translate(-50%, -50%)",
-            pointerEvents: "none",
-          }}
-        />
-      </div>
-
-      <div className="text-sm">
+      <div className="text-sm text-center">
         {new Date(played * 1000).toISOString().substr(14, 5)} /{' '}
         {new Date(duration * 1000).toISOString().substr(14, 5)}
       </div>


### PR DESCRIPTION
## Summary
- place the logo above the title and make the logo fill its yellow square
- redesign custom audio player with a simpler black and yellow style

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684eabace6c08326bb3318108d5f3ed3