### PR TITLE
Add sticky header toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,6 +85,10 @@ export default function App() {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [showPlayers, setShowPlayers] = useState<Record<string, boolean>>({});
   const [search, setSearch] = useState("");
+  const [stickyHeader, setStickyHeader] = useState(() => {
+    const stored = localStorage.getItem("stickyHeader");
+    return stored ? JSON.parse(stored) : true;
+  });
   const [loadingStems, setLoadingStems] = useState<Record<string, boolean>>({});
   const buffersRef = useRef<Record<string, Record<string, AudioBuffer>>>({});
 
@@ -93,6 +97,10 @@ export default function App() {
   useEffect(() => {
     setVideoId(extractVideoId(url));
   }, [url]);
+
+  useEffect(() => {
+    localStorage.setItem("stickyHeader", JSON.stringify(stickyHeader));
+  }, [stickyHeader]);
 
 
   const anyLoading = downloading;
@@ -151,7 +159,9 @@ export default function App() {
 
   return (
     <>
-      <header className="w-full bg-black flex flex-col items-center p-4 space-y-2">
+      <header
+        className={`w-full bg-black flex flex-col items-center p-4 space-y-2 ${stickyHeader ? "sticky top-0 z-10" : ""}`}
+      >
         <div
           className="bg-yellow-400 flex items-center justify-center"
           style={{ width: 64, height: 64 }}
@@ -161,6 +171,15 @@ export default function App() {
         <h1 className="text-3xl sm:text-4xl text-yellow-400 font-extrabold text-center">
           Copyright <span className="text-black bg-yellow-400 px-2">Violation</span>
         </h1>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={stickyHeader}
+            onChange={(e) => setStickyHeader(e.target.checked)}
+            className="text-yellow-400 bg-black border-yellow-400 rounded"
+          />
+          <span className="text-yellow-400 text-sm">Sticky Header</span>
+        </label>
       </header>
 
       <main className="min-h-screen bg-black flex flex-col items-center p-4 sm:p-6 space-y-8 sm:space-y-12">


### PR DESCRIPTION
## Summary
- add sticky header toggle state with persistence
- save preference to localStorage
- toggle sticky header via checkbox

## Testing
- `python -m pytest`
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684eacee39288326830a8680675fe57f