### PR TITLE
Ensure repeat mode keeps UI in sync

### DIFF
--- a/frontend/src/CustomPlayer.tsx
+++ b/frontend/src/CustomPlayer.tsx
@@ -132,15 +132,16 @@ export function CustomPlayer({
       if (ctx && isPlaying) {
         const t = ctx.currentTime - startTimeRef.current;
         setPlayed(t);
-        if (t >= duration) {
-          if (loop) {
-            seekTo(0);
-          } else {
-            pauseOffsetRef.current = duration;
-            sourcesRef.current = {};
-            setIsPlaying(false);
-            setPlayed(duration);
-          }
+          if (t >= duration) {
+            if (loop) {
+              seekTo(0);
+              raf = requestAnimationFrame(update);
+            } else {
+              pauseOffsetRef.current = duration;
+              sourcesRef.current = {};
+              setIsPlaying(false);
+              setPlayed(duration);
+            }
         } else {
           raf = requestAnimationFrame(update);
         }


### PR DESCRIPTION
## Summary
- fix UI not updating when repeat mode loops track

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ebdea35d883268809b2005a3e0f38