### PR TITLE
Add audio upload capability

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@apollo/client": "^3.13.8",
     "graphql": "^16.11.0",
     "graphql-ws": "^6.0.5",
+    "apollo-upload-client": "^17.1.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/frontend/src/graphql/client.ts
+++ b/frontend/src/graphql/client.ts
@@ -1,5 +1,6 @@
 // src/graphql/client.ts
-import { ApolloClient, InMemoryCache, split, HttpLink } from "@apollo/client";
+import { ApolloClient, InMemoryCache, split } from "@apollo/client";
+import { createUploadLink } from "apollo-upload-client";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";
@@ -7,7 +8,7 @@ import { getMainDefinition } from "@apollo/client/utilities";
 // Resolve the backend host dynamically so the frontend works when accessed
 // from other devices on the network. During development the Vite dev server
 // proxies `/graphql` to the Django backend.
-const httpLink = new HttpLink({ uri: "/graphql/" });
+const httpLink = createUploadLink({ uri: "/graphql/" });
 
 const wsProtocol = window.location.protocol === "https:" ? "wss" : "ws";
 const wsLink = new GraphQLWsLink(


### PR DESCRIPTION
## Summary
- allow additional audio extensions in downloads query
- add uploadAudio mutation and Upload scalar in backend
- wire up apollo-upload-client on frontend
- add upload support UI with progress
- include apollo-upload-client dependency

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856030f06cc8326a843c1ec5c0a54d4