### PR TITLE
Fix missing apollo-upload-client

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@apollo/client": "^3.13.8",
+        "apollo-upload-client": "^18.0.1",
         "graphql": "^16.11.0",
         "graphql-ws": "^6.0.5",
         "react": "^19.1.0",
@@ -1975,6 +1976,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apollo-upload-client": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-18.0.1.tgz",
+      "integrity": "sha512-OQvZg1rK05VNI79D658FUmMdoI2oB/KJKb6QGMa2Si25QXOaAvLMBFUEwJct7wf+19U8vk9ILhidBOU1ZWv6QA==",
+      "license": "MIT",
+      "dependencies": {
+        "extract-files": "^13.0.0"
+      },
+      "engines": {
+        "node": "^18.15.0 || >=20.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^3.8.0",
+        "graphql": "14 - 16"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -2593,6 +2613,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-files": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-13.0.0.tgz",
+      "integrity": "sha512-FXD+2Tsr8Iqtm3QZy1Zmwscca7Jx3mMC5Crr+sEP1I303Jy1CYMuYCm7hRTplFNg3XdUavErkxnTzpaqdSoi6g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^4.1.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3057,6 +3092,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "@apollo/client": "^3.13.8",
     "graphql": "^16.11.0",
     "graphql-ws": "^6.0.5",
-    "apollo-upload-client": "^17.1.2",
+    "apollo-upload-client": "^18.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/frontend/src/types/apollo-upload-client.d.ts
+++ b/frontend/src/types/apollo-upload-client.d.ts
@@ -1,0 +1,1 @@
+declare module 'apollo-upload-client';


### PR DESCRIPTION
## Summary
- update `apollo-upload-client` to a real release
- add a minimal TypeScript declaration for the module

## Testing
- `npm run build` *(fails: parameter has an 'any' type)*
- `npm run lint` *(fails: no-unused-vars in `App.tsx`)*


------
https://chatgpt.com/codex/tasks/task_e_685604c4c9288326a92d1196754aedfb