### PR TITLE
Fix import path for apollo-upload-client

### DIFF
--- a/frontend/src/graphql/client.ts
+++ b/frontend/src/graphql/client.ts
@@ -1,6 +1,6 @@
 // src/graphql/client.ts
 import { ApolloClient, InMemoryCache, split } from "@apollo/client";
-import { createUploadLink } from "apollo-upload-client";
+import { createUploadLink } from "apollo-upload-client/createUploadLink.mjs";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";

--- a/frontend/src/types/apollo-upload-client.d.ts
+++ b/frontend/src/types/apollo-upload-client.d.ts
@@ -1,1 +1,1 @@
-declare module 'apollo-upload-client';
+declare module 'apollo-upload-client/createUploadLink.mjs';


### PR DESCRIPTION
## Summary
- update apollo-upload-client import path for ESM export
- declare TypeScript module for the new apollo-upload-client path

## Testing
- `npm run build` *(fails: error TS7006/TS6133/TS2554)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_685620b3dd2883268e3a2895658dc378