### PR TITLE
Fix Apollo upload link import

### DIFF
--- a/frontend/src/graphql/client.ts
+++ b/frontend/src/graphql/client.ts
@@ -1,6 +1,6 @@
 // src/graphql/client.ts
 import { ApolloClient, InMemoryCache, split } from "@apollo/client";
-import { createUploadLink } from "apollo-upload-client/createUploadLink.mjs";
+import createUploadLink from "apollo-upload-client/createUploadLink.mjs";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";


### PR DESCRIPTION
## Summary
- fix import statement for `createUploadLink`

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6856265ae44083269bf980dfbe2f8674