### PR TITLE
Add pitch shifter and BPM analysis

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -15,7 +15,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # ──────────────────────────────────────────────────────────────────────────────
 # SECURITY
 # ──────────────────────────────────────────────────────────────────────────────
-SECRET_KEY = "django-insecure-+5$jm84_i_y&@h4nz79(m75_f*hd8+0z5z@m#q6(_&rvryryi$"
+SECRET_KEY = (
+    "django-insecure-+5$jm84_i_y&@h4nz79(m75_f*hd8+0z5z@m#q6(_&rvryryi$"
+)
 DEBUG = True
 # Allow access from any host when running the dev server so that
 # devices on the local network can reach the backend.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^6.30.1"
+        "react-router-dom": "^6.30.1",
+        "soundtouchjs": "^0.2.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -4343,6 +4344,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/soundtouchjs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/soundtouchjs/-/soundtouchjs-0.2.1.tgz",
+      "integrity": "sha512-ApYdqT4bHqvm6QTRzHDta8PzJIgLacaXdkzUnSdotHvk7N2Ugr9JqV3SlWYsFTsd4ceJHEJqT7JI5E2MYmuQ6w==",
+      "license": "LGPL-2.1"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,14 @@
   },
   "dependencies": {
     "@apollo/client": "^3.13.8",
+    "apollo-upload-client": "^18.0.1",
     "graphql": "^16.11.0",
     "graphql-ws": "^6.0.5",
-    "apollo-upload-client": "^18.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "soundtouchjs": "^0.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ ariadne-django>=0.3
 yt-dlp>=2024.4.0
 daphne>=4
 demucs>=4
+librosa>=0.10
+numpy>=1.26


### PR DESCRIPTION
## Summary
- support BPM & key detection with new AudioAnalysis query
- integrate soundtouchjs in the custom player for tempo and pitch controls
- show sliders for tempo and pitch
- display BPM and key for expanded audio items
- update dependencies for librosa, numpy and soundtouchjs

## Testing
- `npm run lint`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68562b7c973483268b1e706eee86bed9