### PR TITLE
Add paulstretch and show pitch/BPM info

### DIFF
--- a/backend/paulstretch.py
+++ b/backend/paulstretch.py
@@ -1,0 +1,52 @@
+import numpy as np
+import soundfile as sf
+from pathlib import Path
+
+
+def paulstretch_wav(src: Path, dst: Path, stretch: float = 8.0, window: float = 0.25) -> None:
+    data, sr = sf.read(src)
+    if data.ndim > 1:
+        data = data.mean(axis=1)
+    windowsize = int(window * sr)
+    if windowsize < 16:
+        windowsize = 16
+    windowsize = windowsize // 2 * 2
+    half = windowsize // 2
+
+    end_size = int(sr * 0.05)
+    if end_size < 16:
+        end_size = 16
+    if len(data) >= end_size:
+        data[-end_size:] *= np.linspace(1, 0, end_size)
+
+    start_pos = 0.0
+    displace_pos = (windowsize * 0.5) / stretch
+    window_arr = 0.5 - np.cos(np.arange(windowsize, dtype=float) * 2.0 * np.pi / (windowsize - 1)) * 0.5
+    old_buf = np.zeros(windowsize)
+    hinv_sqrt2 = (1 + np.sqrt(0.5)) * 0.5
+    hinv_buf = hinv_sqrt2 - (1.0 - hinv_sqrt2) * np.cos(
+        np.arange(half, dtype=float) * 2.0 * np.pi / half
+    )
+
+    out = []
+    while True:
+        istart_pos = int(np.floor(start_pos))
+        buf = data[istart_pos : istart_pos + windowsize]
+        if len(buf) < windowsize:
+            buf = np.concatenate([buf, np.zeros(windowsize - len(buf))])
+        buf *= window_arr
+        freqs = np.abs(np.fft.rfft(buf))
+        ph = np.random.uniform(0, 2 * np.pi, len(freqs)) * 1j
+        freqs *= np.exp(ph)
+        buf = np.fft.irfft(freqs)
+        buf *= window_arr
+        output = buf[:half] + old_buf[half:windowsize]
+        old_buf = buf
+        output *= hinv_buf
+        output = np.clip(output, -1.0, 1.0)
+        out.append(output)
+        start_pos += displace_pos
+        if start_pos >= len(data):
+            break
+    out_data = np.concatenate(out)
+    sf.write(dst, out_data, sr)

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -70,6 +70,11 @@ type_defs = gql(
       model: String!,
       stems: [String!]!
     ): SeparationResponse!
+    paulStretch(
+      filename: String!,
+      stretch: Float!,
+      window: Float
+    ): DownloadResponse!
     deleteDownload(filename: String!): Boolean!
   }
   type Subscription {
@@ -369,6 +374,24 @@ def resolve_separate_stems(_, __, filename: str, model: str, stems: list[str]):
     logs = f"Using device: {device}{extra}\n" + proc.stdout + proc.stderr
     success = proc.returncode == 0
     return {"success": success, "logs": logs}
+
+
+@mutation.field("paulStretch")
+def resolve_paul_stretch(_, __, filename: str, stretch: float, window: float | None = None):
+    from .paulstretch import paulstretch_wav
+
+    src_path = MEDIA_DIR / filename
+    if not src_path.exists():
+        return {"success": False, "message": "file not found", "downloadUrl": None}
+    vid = Path(filename).stem
+    out_filename = f"{vid}_ps.wav"
+    out_path = MEDIA_DIR / out_filename
+    try:
+        paulstretch_wav(src_path, out_path, stretch=stretch, window=window or 0.25)
+    except Exception as e:
+        return {"success": False, "message": str(e), "downloadUrl": None}
+    rel_url = build_media_url(out_filename)
+    return {"success": True, "message": "", "downloadUrl": rel_url}
 
 
 @mutation.field("deleteDownload")

--- a/frontend/src/soundtouchjs.d.ts
+++ b/frontend/src/soundtouchjs.d.ts
@@ -1,0 +1,11 @@
+declare module 'soundtouchjs' {
+  export class PitchShifter {
+    constructor(context: AudioContext, buffer: AudioBuffer, grainSize?: number);
+    tempo: number;
+    pitchSemitones: number;
+    percentagePlayed: number;
+    connect(node: AudioNode): void;
+    disconnect(): void;
+    on(event: string, cb: (data: any) => void): void;
+  }
+}


### PR DESCRIPTION
## Summary
- implement paulstretch audio processing on backend
- expose paulStretch mutation in GraphQL schema
- add UI for paulstretch with stretch factor prompt
- display original BPM/key and current BPM/key in player
- show numeric tempo and pitch values

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68563816f90083268bcbf393a2850f55