### PR TITLE
Improve player analysis display

### DIFF
--- a/frontend/src/CustomPlayer.tsx
+++ b/frontend/src/CustomPlayer.tsx
@@ -225,7 +225,10 @@ export function CustomPlayer({
       )}
 
       <label className="block text-xs">
-        Tempo ({currentBpm.toFixed(1)} BPM)
+        <div className="flex justify-between">
+          <span>Tempo</span>
+          <span>{currentBpm.toFixed(1)} BPM</span>
+        </div>
         <input
           type="range"
           min={0.5}
@@ -239,7 +242,12 @@ export function CustomPlayer({
       </label>
 
       <label className="block text-xs">
-        Pitch ({pitch} st, Key: {originalKey} → {shiftedKey})
+        <div className="flex justify-between">
+          <span>Pitch</span>
+          <span>
+            {pitch} st, {originalKey} → {shiftedKey}
+          </span>
+        </div>
         <input
           type="range"
           min={-12}

--- a/frontend/src/soundtouchjs.d.ts
+++ b/frontend/src/soundtouchjs.d.ts
@@ -6,6 +6,6 @@ declare module 'soundtouchjs' {
     percentagePlayed: number;
     connect(node: AudioNode): void;
     disconnect(): void;
-    on(event: string, cb: (data: any) => void): void;
+    on(event: string, cb: (data: unknown) => void): void;
   }
 }


### PR DESCRIPTION
## Summary
- show tempo and pitch values with the sliders
- fix lint error in `soundtouchjs.d.ts`

## Testing
- `pytest`
- `npm run lint` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685927e51ef8832696e89089b3c30e40