### PR TITLE
Remove audio analysis and tempo controls

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -51,14 +51,8 @@ type_defs = gql(
     logs: String
   }
 
-  type AudioAnalysis {
-    bpm: Float!
-    key: String!
-  }
-
   type Query {
     downloads: [DownloadedFile!]!
-    audioAnalysis(filename: String!): AudioAnalysis!
   }
 
   type Mutation {
@@ -206,32 +200,6 @@ def resolve_downloads(_, __):
     return items
 
 
-@query.field("audioAnalysis")
-def resolve_audio_analysis(_, __, filename: str):
-    import librosa
-    path = MEDIA_DIR / filename
-    if not path.exists():
-        return {"bpm": 0.0, "key": ""}
-    y, sr = librosa.load(path)
-    tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
-    chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
-    note_names = [
-        "C",
-        "C#",
-        "D",
-        "D#",
-        "E",
-        "F",
-        "F#",
-        "G",
-        "G#",
-        "A",
-        "A#",
-        "B",
-    ]
-    key_index = chroma.mean(axis=1).argmax()
-    key = note_names[int(key_index)]
-    return {"bpm": float(tempo), "key": key}
 
 
 @mutation.field("downloadAudio")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,14 +29,6 @@ const GET_DOWNLOADS = gql`
   }
 `;
 
-const GET_AUDIO_ANALYSIS = gql`
-  query AudioAnalysis($filename: String!) {
-    audioAnalysis(filename: $filename) {
-      bpm
-      key
-    }
-  }
-`;
 
 const DOWNLOAD_AUDIO_PROGRESS = gql`
   subscription DownloadAudioProgress($url: String!) {
@@ -127,7 +119,6 @@ export default function App() {
   });
   const [loadingStems, setLoadingStems] = useState<Record<string, boolean>>({});
   const buffersRef = useRef<Record<string, Record<string, AudioBuffer>>>({});
-  const [analysisData, setAnalysisData] = useState<Record<string, { bpm: number; key: string }>>({});
 
   const searchTerm = search.trim().toLowerCase();
 
@@ -426,19 +417,6 @@ export default function App() {
                               }));
                               if (willExpand) {
                                 preloadStems(f.filename, stemsToShow);
-                                if (!analysisData[f.filename]) {
-                                  client
-                                    .query({
-                                      query: GET_AUDIO_ANALYSIS,
-                                      variables: { filename: f.filename },
-                                    })
-                                    .then(({ data }) => {
-                                      setAnalysisData((a) => ({
-                                        ...a,
-                                        [f.filename]: data.audioAnalysis,
-                                      }));
-                                    });
-                                }
                               }
                             }}
                             className="text-yellow-400"
@@ -486,11 +464,6 @@ export default function App() {
                         <div className="w-full h-2 bg-yellow-400 animate-pulse rounded" />
                       ) : (
                         <>
-                          {analysisData[f.filename] && (
-                            <div className="text-yellow-400 text-xs">
-                              BPM: {analysisData[f.filename].bpm.toFixed(1)} Key: {analysisData[f.filename].key}
-                            </div>
-                          )}
                           <div className="grid grid-cols-3 gap-2">
                             {stemsToShow.map((s: any) => {
                               const detail = STEM_DETAILS[s.name] || {
@@ -532,7 +505,6 @@ export default function App() {
                                 stems={stemsToShow}
                                 selected={Object.keys(sel).filter((k) => sel[k])}
                                 preloaded={buffersRef.current[f.filename] || {}}
-                                analysis={analysisData[f.filename]}
                               />
                             )}
                         </>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ ariadne-django>=0.3
 yt-dlp>=2024.4.0
 daphne>=4
 demucs>=4
-librosa>=0.10
 numpy>=1.26


### PR DESCRIPTION
## Summary
- drop `audioAnalysis` query from backend and cleanup resolver
- drop `librosa` requirement
- remove BPM/key display and tempo/pitch sliders on the frontend

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859306f98fc8326a49409edaf6823c2