### PR TITLE
Add error handling for media tasks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -144,6 +144,10 @@ export default function App() {
         next() {
           // ignore progress text
         },
+        error() {
+          // reset state on error so the UI doesn't get stuck
+          setDownloading(false);
+        },
         complete() {
           setDownloading(false);
           refetch();
@@ -159,6 +163,9 @@ export default function App() {
       .subscribe({
         next() {
           // ignore progress text
+        },
+        error() {
+          setDownloading(false);
         },
         complete() {
           setDownloading(false);
@@ -179,6 +186,9 @@ export default function App() {
         setUploading(false);
         setUploadFile(null);
         refetch();
+      })
+      .catch(() => {
+        setUploading(false);
       });
   };
 
@@ -187,6 +197,9 @@ export default function App() {
       .mutate({ mutation: DELETE_DOWNLOAD, variables: { filename } })
       .then(() => {
         refetch();
+      })
+      .catch(() => {
+        /* ignore errors */
       });
   };
 
@@ -354,6 +367,9 @@ export default function App() {
                   .subscribe({
                     next() {
                       // ignore progress text
+                    },
+                    error() {
+                      setQueue((p: Record<string, boolean>) => ({ ...p, [f.filename]: false }));
                     },
                     complete() {
                       setQueue((p: Record<string, boolean>) => ({ ...p, [f.filename]: false }));

--- a/frontend/src/CustomPlayer.tsx
+++ b/frontend/src/CustomPlayer.tsx
@@ -94,8 +94,9 @@ export function CustomPlayer({
       shifter.connect(gain);
       gain.connect(ctx.destination);
       shifter.percentagePlayed = offset / buffer.duration;
-      shifter.on("play", (d: any) => {
-        setPlayed((d as any).timePlayed);
+      shifter.on("play", (d: unknown) => {
+        const data = d as { timePlayed: number };
+        setPlayed(data.timePlayed);
       });
       sourcesRef.current[name] = { shifter, gain };
     });


### PR DESCRIPTION
## Summary
- handle errors for download and upload actions so UI recovers
- handle errors during stem separation
- tighten CustomPlayer event typing

## Testing
- `npx eslint src/CustomPlayer.tsx src/App.tsx`
- `npm run build`
- `python -m py_compile backend/*.py manage.py`


------
https://chatgpt.com/codex/tasks/task_e_685af062b1008326850dac9f1b6bfdd5