### PR TITLE
Add drag-and-drop support for stems

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ content you are legally allowed to process.
 * Download audio or video via `yt-dlp`
 * Separate audio into stems such as vocals, drums and bass
 * Responsive React interface with a simple player for the isolated stems
+* Drag stem buttons to a DAW or the desktop to download automatically
 
 ## Requirements
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { CustomPlayer, type Stem } from "./CustomPlayer";
 import { gql, useQuery, useApolloClient } from "@apollo/client";
 import {
@@ -345,6 +345,19 @@ export default function App() {
                 });
               };
 
+              const handleDragStart = (
+                e: React.DragEvent<HTMLButtonElement>,
+                name: string
+              ) => {
+                const stem = stems.find((s: any) => s.name === name);
+                if (!stem) return;
+                const downloadName = `${f.title} (${name}).mp3`;
+                e.dataTransfer.setData(
+                  "DownloadURL",
+                  `audio/mpeg:${downloadName}:${stem.url}`
+                );
+              };
+
               const isExpanded = !!expanded[f.filename];
               const isShowingPlayers = !!showPlayers[f.filename];
               const togglePlayers = () => {
@@ -460,6 +473,8 @@ export default function App() {
                                 <button
                                   key={s.name}
                                   onClick={() => toggle(s.name)}
+                                  draggable
+                                  onDragStart={(e) => handleDragStart(e, s.name)}
                                   className={`border border-yellow-400 rounded p-2 flex flex-col items-center justify-center space-y-1 ${selectedStem ? "bg-yellow-400 text-black" : "text-yellow-400"}`}
                                 >
                                   <Icon className="w-6 h-6" />


### PR DESCRIPTION
## Summary
- implement `handleDragStart` to expose stems as downloadable files
- mark stem buttons draggable and handle drag events
- import `React` explicitly for type usage
- document drag-and-drop capability in README

## Testing
- `npm run lint --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_685aef75e98483269c0ff0a02c49c9b3