### PR TITLE
Add custom stem selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ content you are legally allowed to process.
 
 * Download audio or video via `yt-dlp`
 * Separate audio into stems such as vocals, drums and bass
+* Choose exactly which stems to separate for each track
 * Responsive React interface with a simple player for the isolated stems
 * Drag stem buttons to a DAW or the desktop to download automatically
 


### PR DESCRIPTION
## Summary
- give users the option to choose which stems to separate
- support dragging stems with plain text data
- mention custom stem selection in the README

## Testing
- `npm install`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c93c4e1f883268a72a6059287be5b