### PR TITLE
Use local paths for stems

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -46,6 +46,7 @@ type_defs = gql(
   type Stem {
     name: String!
     url: String!
+    path: String!
   }
 
   type SeparationResponse {
@@ -204,6 +205,7 @@ def resolve_downloads(_, __):
                                 f"{vid}/stems/"
                                 f"{stem_file.relative_to(stems_dir)}"
                             ),
+                            "path": str(stem_file.resolve()),
                         }
                     )
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ const GET_DOWNLOADS = gql`
       stems {
         name
         url
+        path
       }
     }
   }
@@ -478,11 +479,7 @@ export default function App() {
                           disabled={inQueue}
                           className="bg-yellow-400 text-black text-sm font-bold px-2 py-1 rounded hover:bg-yellow-300 disabled:opacity-50"
                         >
-                          {inQueue
-                            ? "Separating..."
-                            : missingStems.length
-                            ? "Separate Missing"
-                            : "Separate All"}
+                          {inQueue ? "Separating..." : "Separate"}
                         </button>
                         <button
                           onClick={() => openStems(f.filename)}
@@ -519,15 +516,15 @@ export default function App() {
                                   key={s.name}
                                   href={new URL(s.url, window.location.origin).href}
                                   download={`${f.title} (${s.name}).mp3`}
-                                  draggable
-                                  onDragStart={(e) => {
-                                    const absUrl = new URL(s.url, window.location.origin).href;
-                                    e.dataTransfer.setData("text/uri-list", absUrl);
+                                draggable
+                                onDragStart={(e) => {
+                                    const path = s.path;
+                                    e.dataTransfer.setData("text/uri-list", `file://${path}`);
                                     e.dataTransfer.setData(
                                       "DownloadURL",
-                                      `audio/mp3:${f.title} (${s.name}).mp3:${absUrl}`
+                                      `audio/mp3:${f.title} (${s.name}).mp3:file://${path}`
                                     );
-                                    e.dataTransfer.setData("text/plain", absUrl);
+                                    e.dataTransfer.setData("text/plain", path);
                                   }}
                                   onClick={(e) => {
                                     e.preventDefault();

--- a/frontend/src/CustomPlayer.tsx
+++ b/frontend/src/CustomPlayer.tsx
@@ -5,6 +5,7 @@ import { PitchShifter } from "soundtouchjs";
 export interface Stem {
   name: string;
   url: string;
+  path: string;
 }
 
 


### PR DESCRIPTION
## Summary
- provide `path` field for stems in GraphQL API
- fetch new field in React app
- drag stems using local file path
- simplify separate button text

## Testing
- `npm run build`
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c9f7f577c8326b42c84745cdc099b