### PR TITLE
Update stems UX and open folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ content you are legally allowed to process.
 * Separate audio into stems such as vocals, drums and bass
 * Automatically separates all stems for each track
 * Responsive React interface with a simple player for the isolated stems
-* Drag stem buttons to a DAW or the desktop to download automatically
 
 ## Requirements
 

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -135,6 +135,9 @@ def open_folder(path: Path):
 def resolve_open_stems_folder(_, __, filename: str):
     vid = Path(filename).stem
     stems_dir = MEDIA_DIR / vid / "stems"
+    htdemucs_path = stems_dir / "htdemucs_6s"
+    if htdemucs_path.exists():
+        return open_folder(htdemucs_path)
     if stems_dir.exists():
         return open_folder(stems_dir)
     return False

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,13 +102,7 @@ function extractVideoId(url: string): string | null {
   }
 }
 
-function buildFileUri(path: string): string {
-  let formatted = path.replace(/\\/g, "/");
-  if (!formatted.startsWith("/")) {
-    formatted = "/" + formatted;
-  }
-  return `file://${encodeURI(formatted)}`;
-}
+
 
 export default function App() {
   const [url, setUrl] = useState("");
@@ -511,7 +505,7 @@ export default function App() {
                         <div className="w-full h-2 bg-yellow-400 animate-pulse rounded" />
                       ) : (
                         <>
-                          <div className="grid grid-cols-3 gap-2">
+                          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2">
                             {stemsToShow.map((s: any) => {
                               const detail = STEM_DETAILS[s.name] || {
                                 label: s.name,
@@ -524,17 +518,6 @@ export default function App() {
                                   key={s.name}
                                   href={new URL(s.url, window.location.origin).href}
                                   download={`${f.title} (${s.name}).mp3`}
-                                draggable
-                                onDragStart={(e) => {
-                                    const path = s.path;
-                                    const fileUrl = buildFileUri(path);
-                                    e.dataTransfer.setData("text/uri-list", fileUrl);
-                                    e.dataTransfer.setData(
-                                      "DownloadURL",
-                                      `audio/mp3:${f.title} (${s.name}).mp3:${fileUrl}`
-                                    );
-                                    e.dataTransfer.setData("text/plain", path);
-                                  }}
                                   onClick={(e) => {
                                     e.preventDefault();
                                     toggle(s.name);


### PR DESCRIPTION
## Summary
- remove drag-and-drop stem downloads
- open the `htdemucs_6s` folder when opening stems
- tweak stems grid for better responsiveness
- update README

## Testing
- `npm install`
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ca8b4f62c83268b07cf9b0720acd3