### PR TITLE
Fix UI not updating after operations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -110,7 +110,10 @@ export default function App() {
   const [uploadFiles, setUploadFiles] = useState<File[]>([]);
   const [uploading, setUploading] = useState(false);
 
-  const { data: dlData, refetch } = useQuery(GET_DOWNLOADS);
+  const { data: dlData, refetch } = useQuery(GET_DOWNLOADS, {
+    fetchPolicy: "network-only",
+    pollInterval: 2000,
+  });
 
   const client = useApolloClient();
   const [downloading, setDownloading] = useState(false);


### PR DESCRIPTION
## Summary
- refresh the downloads list from the network and poll periodically so new
  downloads/separations appear without a manual reload

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685f38fffba48326921680f3c2e8243c