### PR TITLE
Improve filename handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ content you are legally allowed to process.
 ## Features
 
 * Download audio or video via `yt-dlp`
+* Files are saved with clean, unique names based on the title
 * Separate audio into stems such as vocals, drums and bass
 * Automatically separates all stems for each track
 * Responsive React interface with a simple player for the isolated stems


### PR DESCRIPTION
## Summary
- sanitize uploaded and downloaded filenames
- rename downloads using title-based names
- save uploads using clean names
- mention filename behavior in README

## Testing
- `python -m py_compile backend/schema.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6861a4d5b60c8326afda4d5c241f4834