### PR TITLE
Revert to random filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ content you are legally allowed to process.
 ## Features
 
 * Download audio or video via `yt-dlp`
-* Files are saved with clean, unique names based on the title
 * Separate audio into stems such as vocals, drums and bass
 * Automatically separates all stems for each track
 * Responsive React interface with a simple player for the isolated stems


### PR DESCRIPTION
## Summary
- remove unique-title naming from README
- revert download functions to use video IDs / random strings

## Testing
- `pytest -q`
- `python -m py_compile backend/schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68626a0a26588326a7b4748818874f5b