### PR TITLE
Refactor download handling and log panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ npm run dev -- --host
 By default the backend listens on `http://localhost:8000` and the frontend on
 `http://localhost:5173`.
 
+### Download workflow
+
+When downloading audio or video the frontend first subscribes to a progress
+stream. The backend runs `yt-dlp` once and writes the final file using a unique
+name derived from the title. After the stream completes the frontend calls the
+matching mutation which simply returns the download URL instead of running
+`yt-dlp` again. This prevents duplicate downloads and leftover temporary files.
+
 ## GPU acceleration
 
 Install the CUDA build of PyTorch to use your GPU:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -145,6 +145,7 @@ export default function App() {
   const MAX_LOG_LINES = 100;
   const [logs, setLogs] = useState<string[]>([]);
   const logsEndRef = useRef<HTMLDivElement | null>(null);
+  const [logCollapsed, setLogCollapsed] = useState(false);
 
   useEffect(() => {
     logsEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -196,15 +197,20 @@ export default function App() {
           const line = res.data?.downloadAudioProgress;
           if (line) setLogs((p) => [...p.slice(-MAX_LOG_LINES + 1), line]);
         },
-      });
-    client
-      .mutate({ mutation: DOWNLOAD_AUDIO, variables: { url } })
-      .then(() => {
-        setDownloading(false);
-        refetch();
-      })
-      .catch(() => {
-        setDownloading(false);
+        error() {
+          setDownloading(false);
+        },
+        complete() {
+          client
+            .mutate({ mutation: DOWNLOAD_AUDIO, variables: { url } })
+            .then(() => {
+              setDownloading(false);
+              refetch();
+            })
+            .catch(() => {
+              setDownloading(false);
+            });
+        },
       });
   };
 
@@ -222,15 +228,20 @@ export default function App() {
           const line = res.data?.downloadVideoProgress;
           if (line) setLogs((p) => [...p.slice(-MAX_LOG_LINES + 1), line]);
         },
-      });
-    client
-      .mutate({ mutation: DOWNLOAD_VIDEO, variables: { url } })
-      .then(() => {
-        setDownloading(false);
-        refetch();
-      })
-      .catch(() => {
-        setDownloading(false);
+        error() {
+          setDownloading(false);
+        },
+        complete() {
+          client
+            .mutate({ mutation: DOWNLOAD_VIDEO, variables: { url } })
+            .then(() => {
+              setDownloading(false);
+              refetch();
+            })
+            .catch(() => {
+              setDownloading(false);
+            });
+        },
       });
   };
 
@@ -661,12 +672,20 @@ export default function App() {
           </div>
       </main>
       {logs.length > 0 && (
-        <pre
-          className="fixed bottom-0 left-0 right-0 max-h-60 overflow-auto bg-black text-yellow-400 p-2 text-xs"
-        >
-          {logs.join("")}
-          <div ref={logsEndRef} />
-        </pre>
+        <div className="fixed bottom-0 left-0 right-0 bg-black text-yellow-400 text-xs">
+          <button
+            onClick={() => setLogCollapsed((p) => !p)}
+            className="absolute right-2 top-1"
+          >
+            {logCollapsed ? "▲" : "▼"}
+          </button>
+          {!logCollapsed && (
+            <pre className="max-h-60 overflow-auto p-2 log-scrollbar">
+              {logs.join("")}
+              <div ref={logsEndRef} />
+            </pre>
+          )}
+        </div>
       )}
     </>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,3 +3,22 @@
 @tailwind components;
 @tailwind utilities;
 
+.log-scrollbar::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.log-scrollbar::-webkit-scrollbar-track {
+  background: #000;
+}
+
+.log-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #facc15;
+  border-radius: 4px;
+}
+
+.log-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: #facc15 #000;
+}
+


### PR DESCRIPTION
## Summary
- avoid running `yt-dlp` twice by doing the download in the progress subscription
- store finished filename and finalize via new lightweight mutations
- customize the log panel with collapsible UI and custom scrollbar
- document the simplified download workflow

## Testing
- `python -m py_compile backend/schema.py`
- `npm run build` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862d5c2d88c8326b42212f79715835b