### PR TITLE
Enhance download progress handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -203,12 +203,18 @@ export default function App() {
         complete() {
           client
             .mutate({ mutation: DOWNLOAD_AUDIO, variables: { url } })
-            .then(() => {
+            .then(({ data }) => {
+              const dl = data?.downloadAudio;
+              if (dl?.downloadUrl) {
+                const a = document.createElement("a");
+                a.href = dl.downloadUrl;
+                a.download = "";
+                a.click();
+              }
+            })
+            .finally(() => {
               setDownloading(false);
               refetch();
-            })
-            .catch(() => {
-              setDownloading(false);
             });
         },
       });
@@ -234,12 +240,18 @@ export default function App() {
         complete() {
           client
             .mutate({ mutation: DOWNLOAD_VIDEO, variables: { url } })
-            .then(() => {
+            .then(({ data }) => {
+              const dl = data?.downloadVideo;
+              if (dl?.downloadUrl) {
+                const a = document.createElement("a");
+                a.href = dl.downloadUrl;
+                a.download = "";
+                a.click();
+              }
+            })
+            .finally(() => {
               setDownloading(false);
               refetch();
-            })
-            .catch(() => {
-              setDownloading(false);
             });
         },
       });
@@ -539,7 +551,6 @@ export default function App() {
                           onClick={() => startSeparation()}
                           disabled={inQueue}
                           className="bg-yellow-400 text-black text-sm font-bold px-2 py-1 rounded hover:bg-yellow-300 disabled:opacity-50"
-                          className="bg-yellow-400 text-black text-sm font-bold px-2 py-1 rounded hover:bg-yellow-300 disabled:opacity-50"
                         >
                           {inQueue ? "Separating..." : "Separate"}
                         </button>
@@ -672,13 +683,16 @@ export default function App() {
           </div>
       </main>
       {logs.length > 0 && (
-        <div className="fixed bottom-0 left-0 right-0 bg-black text-yellow-400 text-xs">
-          <button
-            onClick={() => setLogCollapsed((p) => !p)}
-            className="absolute right-2 top-1"
-          >
-            {logCollapsed ? "▲" : "▼"}
-          </button>
+        <div className="fixed bottom-0 left-0 right-0 bg-black text-yellow-400 text-xs border-t border-yellow-400">
+          <div className="flex justify-end">
+            <div
+              className="flex items-center gap-1 p-2 cursor-pointer select-none"
+              onClick={() => setLogCollapsed((p) => !p)}
+            >
+              <span className="font-bold text-sm">Logs</span>
+              <button>{logCollapsed ? "▲" : "▼"}</button>
+            </div>
+          </div>
           {!logCollapsed && (
             <pre className="max-h-60 overflow-auto p-2 log-scrollbar">
               {logs.join("")}


### PR DESCRIPTION
## Summary
- automatically trigger file download once audio/video is ready
- ensure progress bar stops after download
- move log panel header to the right

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: missing React deps)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862df28c7c0832694cfa1b6b1f43316