### PR TITLE
Fix delete mutation and adjust logs footer

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -149,6 +149,27 @@ def unique_filename(title: str, ext: str) -> tuple[str, str]:
     return f"{candidate}{ext}", candidate
 
 
+@mutation.field("deleteDownload")
+def resolve_delete_download(_, __, filename: str):
+    vid = Path(filename).stem
+    try:
+        file_path = MEDIA_DIR / filename
+        if file_path.exists():
+            if file_path.is_dir():
+                shutil.rmtree(file_path, ignore_errors=True)
+            else:
+                file_path.unlink()
+        dir_path = MEDIA_DIR / vid
+        if dir_path.exists():
+            shutil.rmtree(dir_path, ignore_errors=True)
+        meta_path = MEDIA_DIR / f"{vid}.json"
+        if meta_path.exists():
+            meta_path.unlink()
+        return True
+    except Exception:
+        return False
+
+
 def open_folder(path: Path):
     try:
         if sys.platform.startswith("win"):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -683,7 +683,7 @@ export default function App() {
           </div>
       </main>
       {logs.length > 0 && (
-        <div className="fixed bottom-0 left-0 right-0 bg-black text-yellow-400 text-xs border-t border-yellow-400">
+        <footer className="bg-black text-yellow-400 text-xs border-t border-yellow-400">
           <div className="flex justify-end">
             <div
               className="flex items-center gap-1 p-2 cursor-pointer select-none"
@@ -699,7 +699,7 @@ export default function App() {
               <div ref={logsEndRef} />
             </pre>
           )}
-        </div>
+        </footer>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- implement `deleteDownload` mutation on the backend
- place logs panel at bottom of page instead of fixed overlay

## Testing
- `npm install`
- `npm run lint`
- `python -m py_compile backend/schema.py`


------
https://chatgpt.com/codex/tasks/task_e_686439079634832689447fb53dae1f8c