### PR TITLE
Update logs default sticky

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -142,7 +142,7 @@ export default function App() {
   });
   const [stickyLogs, setStickyLogs] = useState(() => {
     const stored = localStorage.getItem("stickyLogs");
-    return stored ? JSON.parse(stored) : false;
+    return stored ? JSON.parse(stored) : true;
   });
   const [loadingStems, setLoadingStems] = useState<Record<string, boolean>>({});
   const buffersRef = useRef<Record<string, Record<string, AudioBuffer>>>({});


### PR DESCRIPTION
## Summary
- set `stickyLogs` default to `true`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686442d0921c8326b38c752b4895ad9b