### PR TITLE
Fix card updates and stem URLs

### DIFF
--- a/backend/schema.py
+++ b/backend/schema.py
@@ -61,9 +61,10 @@ def list_stems_for(vid: str) -> list[dict]:
     out = []
     if stems_dir.exists():
         for f in sorted(stems_dir.rglob("*.mp3")):
+            rel = f.relative_to(stems_dir).as_posix()
             out.append({
                 "name": Path(f).stem,
-                "url":   MEDIA_URL + f"{vid}/stems/{f.name}",
+                "url":   MEDIA_URL + f"{vid}/stems/{rel}",
                 "path":  str(f.resolve()),
             })
     return out

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,33 +1,17 @@
 // src/App.tsx
-import React from "react";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 import DownloadForm from "./components/DownloadForm";
 import UploadForm from "./components/UploadForm";
 import DownloadList from "./components/DownloadList";
-import { useQuery, useMutation } from "@apollo/client";
-import { DOWNLOAD_AUDIO } from "./graphql/mutations";
+import { useQuery } from "@apollo/client";
 import { GET_DOWNLOADS } from "./graphql/queries";
 
 export default function App() {
   // 1) load all existing downloads
-  const { data, loading, error, refetch } = useQuery(GET_DOWNLOADS);
+  const { data, loading, error } = useQuery(GET_DOWNLOADS);
   const downloads = data?.downloads ?? [];
-
-  // 2) one mutation to download+separate on the server
-  const [downloadAudio, { loading: downloading }] = useMutation(
-    DOWNLOAD_AUDIO,
-    {
-      onCompleted: () => {
-        // once the server is done, refresh the list
-        refetch();
-      },
-      onError: (e) => {
-        console.error("Download+Separate failed:", e);
-      },
-    }
-  );
 
   return (
     <div className="flex flex-col h-screen bg-black text-yellow-400">
@@ -50,11 +34,7 @@ export default function App() {
       {/* Main */}
       <main className="flex-1 overflow-auto p-6 space-y-8">
         {/* Download by URL */}
-        <DownloadForm
-          onNewDownload={(url: string) => {
-            if (!downloading) downloadAudio({ variables: { url } });
-          }}
-        />
+        <DownloadForm />
 
         {/* Upload from file */}
         <UploadForm />

--- a/frontend/src/components/CustomPlayer.tsx
+++ b/frontend/src/components/CustomPlayer.tsx
@@ -1,5 +1,5 @@
 // src/components/CustomPlayer.tsx
-import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { FaPause, FaPlay, FaRedo } from "react-icons/fa";
 import { PitchShifter } from "soundtouchjs";
 import { toast } from "react-toastify";
@@ -102,7 +102,7 @@ export default function CustomPlayer({
         shifter.connect(gain);
         gain.connect(ctx.destination);
         shifter.percentagePlayed = offset / buffer.duration;
-        shifter.on("play", (d: any) => setPlayed(d.timePlayed));
+        shifter.on("play", (d: { timePlayed: number }) => setPlayed(d.timePlayed));
 
         sourcesRef.current[name] = { shifter, gain };
       });
@@ -121,7 +121,9 @@ export default function CustomPlayer({
     Object.values(sourcesRef.current).forEach(({ shifter }) => {
       try {
         shifter.disconnect();
-      } catch {}
+      } catch {
+        // ignore errors during disconnect
+      }
     });
     sourcesRef.current = {};
     setIsPlaying(false);

--- a/frontend/src/components/DownloadForm.tsx
+++ b/frontend/src/components/DownloadForm.tsx
@@ -1,15 +1,11 @@
 // src/components/DownloadForm.tsx
-import React, { useState } from "react";
+import { useState } from "react";
 import { useMutation } from "@apollo/client";
 import { DOWNLOAD_AUDIO } from "../graphql/mutations";
 import { GET_DOWNLOADS } from "../graphql/queries";
 import { toast } from "react-toastify";
 
-interface Props {
-  onNewDownload: (url: string) => void;
-}
-
-export default function DownloadForm({ onNewDownload }: Props) {
+export default function DownloadForm() {
   const [url, setUrl] = useState("");
 
   const [downloadAudio, { loading }] = useMutation(DOWNLOAD_AUDIO, {
@@ -32,7 +28,6 @@ export default function DownloadForm({ onNewDownload }: Props) {
     if (!trimmed) return;
     try {
       await downloadAudio({ variables: { url: trimmed } });
-      onNewDownload(trimmed);
       setUrl("");
     } catch {
       // error already shown by onError

--- a/frontend/src/components/DownloadItemCard.tsx
+++ b/frontend/src/components/DownloadItemCard.tsx
@@ -1,5 +1,5 @@
 // src/components/DownloadItemCard.tsx
-import React, { useState } from "react";
+import { useState } from "react";
 import { useApolloClient } from "@apollo/client";
 import { toast } from "react-toastify";
 import { DELETE_DOWNLOAD } from "../graphql/mutations";
@@ -38,8 +38,9 @@ export default function DownloadItemCard({ audio }: Props) {
       } else {
         toast.error("Delete failed");
       }
-    } catch (err: any) {
-      toast.error(`Error deleting: ${err.message}`);
+    } catch (err: unknown) {
+      const message = (err as Error).message ?? String(err);
+      toast.error(`Error deleting: ${message}`);
     }
   };
 

--- a/frontend/src/components/DownloadList.tsx
+++ b/frontend/src/components/DownloadList.tsx
@@ -1,5 +1,4 @@
 // src/components/DownloadList.tsx
-import React from "react";
 import DownloadItemCard from "./DownloadItemCard";
 import type { DownloadedAudio } from "./DownloadItemCard";
 

--- a/frontend/src/components/UploadForm.tsx
+++ b/frontend/src/components/UploadForm.tsx
@@ -1,5 +1,5 @@
 // src/components/UploadForm.tsx
-import React, { useState, DragEvent } from "react";
+import { useState, type DragEvent } from "react";
 import { useMutation, useApolloClient } from "@apollo/client";
 import { toast } from "react-toastify";
 import { UPLOAD_AUDIO } from "../graphql/mutations";

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,4 @@
 // src/index.tsx
-import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css"; // your tailwind or global styles


### PR DESCRIPTION
## Summary
- prevent duplicate download mutations
- update stem URL generation to include subfolders
- remove unused React imports and improve error handling
- quiet ESLint issues

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869926887f08326bd843a6350cec8bf